### PR TITLE
Adding condition isdigit to get es version

### DIFF
--- a/es_pandas/es_pandas.py
+++ b/es_pandas/es_pandas.py
@@ -20,7 +20,7 @@ class es_pandas(object):
         self.dtype_mapping = {'text': 'category', 'date': 'datetime64[ns]'}
         self.id_col = '_id'
         self.es_version_str = self.es.info()['version']['number']
-        self.es_version = [int(x) for x in self.es_version_str.split('.')]
+        self.es_version = [int(x) for x in self.es_version_str.split('.') if x.isdigit()]
         if self.es_version[0] < 6:
             warnings.warn('Supporting of ElasticSearch 5.x will by deprecated in future version, '
                           'current es version: %s' % self.es_version_str, category=FutureWarning)


### PR DESCRIPTION
Adding workaround to avoid exception when elasticsearch version has `SNAPSHOT` at the end. 
we should be good ignoring the last part of it since we only need the mayor release (first number of the version). 
Fixes #22 